### PR TITLE
Updated readme.md to point to the right version of sginfo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ ed = serialED.serialED(data)
 
 - Python3.6
 - [HyperSpy](http://hyperspy.org/)
-- [sginfo](http://cci.lbl.gov/sginfo/) must be available as `sginfo` on the search path
+- An updated version of [sginfo](http://cci.lbl.gov/sginfo/) must be available as `sginfo` on the search path. It is available as part of the [focus package](https://github.com/stefsmeets/focus_package/tree/master/focus/src/sginfo)
 - ...
 
 ## Install using Conda


### PR DESCRIPTION
It can be tricky for new users to find and install the correct version of sginfo, particularly considering that the original isn't maintained anymore. Adding the URL to the updated from @stefsmeets version right in the readme should solve this issue (e.g. [issue #2 ](https://github.com/stefsmeets/problematic/issues/2)). 