### PR TITLE
Solved incompatibility issues for up to date libraries.

### DIFF
--- a/problematic/hdf5_to_hyperspy.py
+++ b/problematic/hdf5_to_hyperspy.py
@@ -11,12 +11,12 @@ def hdf5_to_hyperspy(fns):
 
     dat = []
     for fn in fns:
-        f = h5py.File(fn)
+        f = h5py.File(fn, 'r')
         dat.append(np.array(f["data"]))
         f.close()
     
     try:
-        f = h5py.File(fn)
+        f = h5py.File(fn, 'r')
         pixelsize = f["data"].attrs["ImagePixelsize"]
     except KeyError:
         pixelsize = 1

--- a/problematic/indexer.py
+++ b/problematic/indexer.py
@@ -119,6 +119,8 @@ def get_indices(pks, scale, center, shape, hkl=None):
 
 # store the results of indexing
 IndexingResult = namedtuple("IndexingResult", ["score", "number", "alpha", "beta", "gamma", "center_x", "center_y", "scale", "phase"])
+IndexingResultDType = [("score", '<f8'), ("number", '<i8'), ("alpha", '<f8'), ("beta", '<f8'), ("gamma", '<f8'), 
+                ("center_x", '<f8'), ("center_y", '<f8'), ("scale", '<f8'), ("phase", '<S16')]
 
 # description of each projection
 ProjInfo = namedtuple("ProjectionInfo", ["number", "alpha", "beta"])
@@ -426,7 +428,7 @@ class Indexer(object):
                                   scale=round(scale, 4),
                                   phase=phase) for (score, n, gamma) in heap]
 
-        return results
+        return np.array(results, dtype=IndexingResultDType)
     
     def plot_all(self, img, results, **kwargs):
         """
@@ -592,7 +594,7 @@ class Indexer(object):
                                  scale=scale,
                                  phase=result.phase)
         
-        return refined
+        return np.array(refined, dtype=IndexingResultDType).view(np.recarray)
 
     def probability_distribution(self, img, result, projector=None, verbose=True, vary_center=False, vary_scale=True):
         """https://lmfit.github.io/lmfit-py/fitting.html#lmfit.minimizer.Minimizer.emcee

--- a/problematic/spacegroup.py
+++ b/problematic/spacegroup.py
@@ -582,7 +582,7 @@ class SpaceGroup(object):
         from laue_symops import symops
         lauegr = self.laue_group
 
-        if self.setting:
+        if self.setting in ('a', 'b', 'c'):
             lauegr += f":{self.setting[0]}"
 
         return (SymOp.from_str(op) for op in symops[lauegr])

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
 
     packages=["problematic",],
 
-    install_requires=["numpy", "scipy", "pandas", "scikit-image", "pyyaml", "lmfit", "cython", "h5py"],
+    install_requires=["numpy", "scipy", "pandas", "scikit-image", "pyyaml", "lmfit", "cython", "h5py", 'hyperspy'],
 
     package_data={
         "": ["LICENCE",  "readme.md", "setup.py"],


### PR DESCRIPTION
Solved some incompatibility issues for updated libraries.
1. Wanings popped up for h5py.File function without explicitly designate the access level. Add 'r'
2. hyperspy map function will convert namedtuple "IndexingResult" to np.ndarray. All the attributes are lost. Use np.recarray to solve this issue.